### PR TITLE
Horizontal text output and bug squash

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ It will produce an e-reader friendly, valid EPUB3 document.
 
 ## Chapter Range
 If you would prefer to download specific chapters, and not the whole novel, add the flag --min # and/or --max #, such as ```python syosetu2epub.py https://*syosetu.com/****** --min 10 --max 50```
+
+## Horizontal Text
+Default mode outputs text vertically and flip pages from right to left.
+Use the flag ```--horizontal``` in order to read text horizontally and flip pages from left to right.

--- a/files/chaptertemplate.xhtml
+++ b/files/chaptertemplate.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="ja" lang="ja">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="ja" lang="ja" class="${HTMLCLASS}">
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="style.css" type="text/css" />

--- a/files/content.opf
+++ b/files/content.opf
@@ -22,7 +22,7 @@
         <item media-type="application/x-dtbncx+xml" href="toc.ncx" id="_toc.ncx" />
         ${CHAPTERSTAG}
     </manifest>
-    <spine page-progression-direction="rtl" toc="_toc.ncx">
+    <spine page-progression-direction="${PAGEDIRECTION}" toc="_toc.ncx">
         <itemref idref="_titlepage.xhtml" />
         <itemref idref="_nav.xhtml" />
         ${SPINETAG}

--- a/files/nav.xhtml
+++ b/files/nav.xhtml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:ibooks="http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0" epub:prefix="ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0" xml:lang="ja" lang="ja">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:ibooks="http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0" epub:prefix="ibooks: http://vocabulary.itunes.apple.com/rdf/ibooks/vocabulary-extensions-1.0" xml:lang="ja" lang="ja" class="${HTMLCLASS}">
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="style.css" type="text/css" />

--- a/syosetu2epub.py
+++ b/syosetu2epub.py
@@ -9,6 +9,7 @@ import string
 from datetime import datetime
 import requests
 import pytz
+from html import escape
 
 cwd = os.getcwd()
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -40,6 +41,7 @@ class Novel:
         # get author, title
         self.title = self.page.find(class_="p-novel__title").text
         self.title = "".join(c for c in self.title if c.isalnum() or c in " 【】「」").rstrip()
+        self.title = escape(self.title)
         self.author = self.page.find(class_="p-novel__author").text.split('：', 1)[1]
 
         self.tocInsert = ""
@@ -62,9 +64,9 @@ class Novel:
             for item in indexBox.find_all(["div", "a"]):
                 class_name = item.get("class")[0]
                 if "chapter-title" in class_name:
-                    tocInsert = "<li><span>" + item.contents[0] + "</span></li>\n"
+                    tocInsert = "<li><span>" + escape(item.contents[0]) + "</span></li>\n"
                 elif "subtitle" in class_name:
-                    title = item.contents[0]
+                    title = escape(item.contents[0])
                     self.chapterCount += 1
                     
                     if self.chapterCount < min_chapter:
@@ -139,6 +141,7 @@ class Novel:
             print(f"Downloading chapter {i + 1}/{max_chapter}")
             thisChapter = BeautifulSoup(SyosetuRequest(self.link + "/" + str(i+1)).getPage(), 'html.parser')
             title = thisChapter.find(class_="p-novel__title").text
+            title = escape(title)
             chapterText = "<h2 id=\"toc_index_1\">" + title + "</h2>\n"
 
             sectionTexts = [adjust(text) for text in thisChapter.find_all(class_="js-novel-text")]
@@ -220,12 +223,14 @@ if __name__ == "__main__":
         if "--min" in arg:
             if i + 1 < len(sys.argv) and str.isdigit(sys.argv[i + 1]):
                 min_chapter = int(sys.argv[i + 1])
+                skip_next = True
             else:
                 print("Error: No min_chapter found after --min.")
                 os._exit(0)
         if "--max" in arg:
             if i + 1 < len(sys.argv) and str.isdigit(sys.argv[i + 1]):
                 max_chapter = int(sys.argv[i + 1])
+                skip_next = True
             else:
                 print("Error: No min_chapter found after --max.")
                 os._exit(0)

--- a/syosetu2epub.py
+++ b/syosetu2epub.py
@@ -14,6 +14,8 @@ cwd = os.getcwd()
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 compact = False
+horizontal_class = ''
+page_direction = 'rtl'
 min_chapter = 0
 max_chapter = 100000000
 
@@ -110,7 +112,7 @@ class Novel:
         # THE FOLLOWING WRITES THE COMPLETE TABLE OF CONTENTS AND TITLE PAGE FILES
         with open(os.path.join(__location__, 'files/nav.xhtml'), encoding="utf-8") as t:
             template = string.Template(t.read())
-            finalOutput = template.substitute(TITLETAG=self.title, TOCTAG=self.tocInsert)
+            finalOutput = template.substitute(TITLETAG=self.title, TOCTAG=self.tocInsert, HTMLCLASS=horizontal_class)
             oebpsDir = os.path.join(tempDir.name, self.title, "OEBPS")
             with open(os.path.join(oebpsDir, "nav.xhtml"), "w", encoding="utf-8") as output:
                 output.write(finalOutput)
@@ -144,7 +146,7 @@ class Novel:
 
             with open(os.path.join(__location__, 'files/chaptertemplate.xhtml'), encoding="utf-8") as t:
                 template = string.Template(t.read())
-                finalOutput = template.substitute(TITLETAG=title, BODYTAG=chapterText)
+                finalOutput = template.substitute(TITLETAG=title, BODYTAG=chapterText, HTMLCLASS=horizontal_class)
                 with open(os.path.join(tempDir.name, self.title, 'OEBPS', (str(i + 1) + '.xhtml')), "w", encoding="utf-8") as output:
                     output.write(finalOutput)
             chapterList += "<item media-type=\"application/xhtml+xml\" href=\"" + \
@@ -154,7 +156,7 @@ class Novel:
         with open(os.path.join(__location__, 'files/content.opf'), encoding="utf-8") as t:
             template = string.Template(t.read())
             finalOutput = template.substitute(IDTAG=self.seriesCode, TITLETAG=self.title, AUTHORTAG=self.author, TIMESTAMPTAG=datetime.now(
-                pytz.utc).isoformat().split('.', 1)[0] + 'Z', CHAPTERSTAG=chapterList, SPINETAG=chapterListSpine)
+                pytz.utc).isoformat().split('.', 1)[0] + 'Z', CHAPTERSTAG=chapterList, SPINETAG=chapterListSpine, PAGEDIRECTION=page_direction)
             oebpsDir = os.path.join(tempDir.name, self.title, "OEBPS")
             with open(os.path.join(oebpsDir, "content.opf"), "w", encoding="utf-8") as output:
                 output.write(finalOutput)
@@ -212,6 +214,9 @@ if __name__ == "__main__":
             link = arg
         if "-c" in arg:
             compact = True
+        if "--horizontal" in arg:
+            horizontal_class = 'horizontal'
+            page_direction = 'ltr'
         if "--min" in arg:
             if i + 1 < len(sys.argv) and str.isdigit(sys.argv[i + 1]):
                 min_chapter = int(sys.argv[i + 1])
@@ -231,6 +236,7 @@ if __name__ == "__main__":
             print("`-c`: Syosetu.com adds large spacing between blocks of text via br tags, which may greatly reduce the amount of words per page shown. Use `-c` to enable compact mode and ignore these spacers.")
             print("`--min`: Minimum chapter to start downloading from.")
             print("`--max`: Maximum chapter to download until.")
+            print("`--horizontal`: Displays text horizontally instead of vertically. Scrolling between pages will also be from left to right instead of right to left.")
             os._exit(0)
 
     if link == None:

--- a/template/OEBPS/style.css
+++ b/template/OEBPS/style.css
@@ -9,6 +9,13 @@ html {
   font-family: serif, sans-serif;
 }
 
+html.horizontal {
+  -ms-writing-mode: lr-tb;
+  -epub-writing-mode: horizontal-tb;
+  -webkit-writing-mode: horizontal-tb;
+  writing-mode: horizontal-tb;
+}
+
 body {
   text-align: justify;
   text-justify: inter-ideograph;
@@ -215,12 +222,12 @@ p {
   margin: 0;
 }
 
-a {
+a, u {
   text-decoration: overline;
 }
 
-u {
-  text-decoration: overline;
+.horizontal a, .horizontal u {
+  text-decoration: underline;
 }
 
 em {


### PR DESCRIPTION
There are two parts this this pull request. The bug fix is small, so I figured I would include it with the new feature, to not bug you with multiple pull requests.

1) --horizontal flag which allows displaying the novel text horizontally instead of vertically. This also switches page reading direction from default of right-to-left to left-to-right.

2) Escaping output of book and chapter titles. I ran into a chapter which included "<TEXT>" which broke the epub. At first I only escaped the chapter title, however I'm sure somewhere there is a book title that probably contains something that should be escaped as well, so I preemptively added escaping for that as well.

The following should create a broken epub without escaping and work with escaping:

`python syosetu2epub.py -c https://ncode.syosetu.com/n7543gq --min 34 --max 34`

Anyway, thank you for a great repo!